### PR TITLE
Update custom cutscene/attract replay loading

### DIFF
--- a/src_rebuild/GAME/C/CUTSCENE.C
+++ b/src_rebuild/GAME/C/CUTSCENE.C
@@ -313,7 +313,7 @@ void DrawInGameCutscene(void)
 			// [A] print user chaser name on screen
 			char tempStr[80];
 
-			sprintf(tempStr, "Recorded by %s", gUserReplayFolderList[gUserChaseLoaded]);
+			sprintf(tempStr, "Getaway is %s", gUserReplayFolderList[gUserChaseLoaded]);
 
 			SetTextColour(128, 128, 64);
 			PrintString(tempStr, 16, 230);

--- a/src_rebuild/GAME/C/REPLAYS.C
+++ b/src_rebuild/GAME/C/REPLAYS.C
@@ -587,7 +587,25 @@ int LoadReplayFromBuffer(char *buffer)
 	return 1;
 }
 
+#ifndef PSX
+int LoadUserAttractReplay(int mission, int userId)
+{
+	char customFilename[64];
+	
+	if (userId >= 0 && userId < gNumUserChases)
+	{
+		sprintf(customFilename, "REPLAYS\\User\\%s\\ATTRACT.%d", gUserReplayFolderList[userId], mission);
 
+		if (FileExists(customFilename))
+		{
+			if (Loadfile(customFilename, _other_buffer))
+				return LoadReplayFromBuffer(_other_buffer);
+		}
+	}
+
+	return 0;
+}
+#endif
 
 // decompiled code
 // original method signature: 
@@ -618,33 +636,25 @@ int LoadAttractReplay(int mission)
 	char filename[32];
 
 #ifndef PSX
-	int userFolderId;
+	int userId = -1;
 	
 	// [A] REDRIVER2 PC - custom attract replays
 	if (gNumUserChases)
 	{
-		userFolderId = rand() % (gNumUserChases + 1);
+		userId = rand() % (gNumUserChases + 1);
 
-		if (userFolderId == gNumUserChases)
-			userFolderId = -1;
-
-		if (userFolderId >= 0)
-		{
-			// optional randomization
-			sprintf(filename, "REPLAYS\\ATTRACT.%d.%s", mission, gUserReplayFolderList[userFolderId]);
-
-			if (!FileExists(filename))
-				userFolderId = -1;
-		}
+		if (userId == gNumUserChases)
+			userId = -1;
 	}
-	else
-		userFolderId = -1;
 
-	if(userFolderId == -1)
-		sprintf(filename,"REPLAYS\\ATTRACT.%d", mission);
-#else
-	sprintf(filename,"REPLAYS\\ATTRACT.%d", mission);
+	if (LoadUserAttractReplay(mission, userId))
+	{
+		printInfo("Loaded custom attract replay (%d) by %s\n", mission, gUserReplayFolderList[userId]);
+		return 1;
+	}
 #endif
+
+	sprintf(filename, "REPLAYS\\ATTRACT.%d", mission);
 
 	if (!FileExists(filename))
 		return 0;


### PR DESCRIPTION
New layout for custom cutscene/attract files.

## Cutscenes
For user replays with a name:
`Replays\User\<name>\CUT<mission>_<subindex>.D2RP`

For user replays without a name:
`Replays\User\CUT<mission>_<subindex>.D2RP`

## Attracts
For user replays with a name:
`Replays\User\<name>\ATTRACT.<mission>`

For user replays without a name:
`Replays\ATTRACT.<mission>` _(default - no change)_

This replaces the old layout and is quite easy to migrate.