### PR TITLE
fixed Main Menu extended ASCII char missing

### DIFF
--- a/src_rebuild/GAME/FRONTEND/FEMAIN.C
+++ b/src_rebuild/GAME/FRONTEND/FEMAIN.C
@@ -1945,22 +1945,22 @@ int FEPrintString(char *string, int x, int y, int justification, int r, int g, i
 
 	FE_CHARDATA *pFontInfo;
 	SPRT *font;
-	char let;
+	unsigned char let;
 
 	font = (SPRT *)current->primptr;
-	
+
 	if (justification & 4)
 	{
 		char *pString = string;
-		char c = 0;
+		unsigned char c = 0;
 
 		int w = 0;
 
-		while ((c = *pString++) != 0) 
+		while ((c = *pString++) != 0)
 		{
-			if (c == ' ') 
+			if (c == ' ')
 				w += 4;
-			else 
+			else
 				w += feFont.CharInfo[c].w;
 		}
 


### PR DESCRIPTION
before fix https://i.imgur.com/HfWZB4o.png
After fix https://i.imgur.com/8sKZeAJ.png

looks like it could affect anything that is above 127
that letter is `'é' = 0xE9`

I haven't check anywhere else as the pause menu is using English instead of French.
When I have time i will check the story mode