### PR TITLE
Psx fixes

### DIFF
--- a/PSXToolchain/Makefile
+++ b/PSXToolchain/Makefile
@@ -83,15 +83,15 @@ SRCS = \
   $(SOURCES)/C/wheelforces.c\
   $(SOURCES)/C/xaplay.c\
   $(SOURCES)/C/xmplay.c
-  
+
 # overlay sources
 SRCS += \
   $(SOURCES)/Frontend/FEmain.c\
   $(SOURCES)/C/pathfind.c\
   $(SOURCES)/C/leadai.c
-  
-SRCS += $(PSYQ_DIR)/common/crt0/crt0.s 
-INCL = $(SOURCES) $(PSYQ_DIR)/include $(NPSYQ_DIR)/include
+
+SRCS += $(PSYQ_DIR)/common/crt0/crt0.s
+INCL = $(SOURCES) $(PSYQ_DIR)/include $(PSYQ_DIR)/include/sys $(NPSYQ_DIR)/include
 
 DEFS = PSX NTSC_VERSION RELOC DEBUG_OPTIONS
 

--- a/PSXToolchain/README.md
+++ b/PSXToolchain/README.md
@@ -5,6 +5,8 @@ In order to start building a Playstation version of **REDRIVER2** you'll need to
  - Put **mipsel-unknown-elf** toolchain to this folder (https://github.com/majenkotech/mipsel-unknown-elf/releases)
  - Install **make**
  - Obtain **Psy-Q SDK** converted for *latest GCC*
+ - Copy (https://github.com/pcsx-redux/nugget/tree/main/common) to `/PSXToolchain/PsyQ/common`
  - Execute **psx_build.bat**
+ - Install [mkpsxiso](https://github.com/Lameguy64/mkpsxiso/releases)
  - Execute **psx_makecd.bat**
  - Locate and use **CDSrc/REDRIVER2.bin** and **cue** files

--- a/PSXToolchain/psx_build.bat
+++ b/PSXToolchain/psx_build.bat
@@ -1,4 +1,4 @@
-set REDRIVER_FOLDER=%cd%/..
+set REDRIVER_FOLDER=%cd%\..
 
 rem Make a symlink
 mklink /J %REDRIVER_FOLDER%\PSXToolchain\GameSRC %REDRIVER_FOLDER%\src_rebuild

--- a/PSXToolchain/psx_build.bat
+++ b/PSXToolchain/psx_build.bat
@@ -7,6 +7,13 @@ rem Create a virtual drive
 SUBST X: %REDRIVER_FOLDER%\PSXToolchain
 
 set PATH=%PATH%;X:\mipsel-unknown-elf\bin;
+
+if exist %REDRIVER_FOLDER%\PSXToolchain\CDSrc\0_CD_DATA\ (
+  rem Yes
+) else (
+  mkdir %REDRIVER_FOLDER%\PSXToolchain\CDSrc\0_CD_DATA\
+)
+
 make
 
 rem Cleanup


### PR DESCRIPTION
First commit fixed this error
```
D:\dev\REDRIVER2_upstream\PSXToolchain/..\src_rebuild
Invalid switch - "..\PSXToolchain\GameSRC".
```

Second
```
GameSRC/Game/driver2.h:4:10: fatal error: types.h: No such file or directory
    4 | #include <types.h>
      |          ^~~~~~~~~
```

There are many other issues:
- dep files are generated with system headers
- crt0 was missing, the include inside file doesn't work
- mkpsxiso doesn't take LBA2 argument