### PR TITLE
Capture the flag: fix flag blip color and score text alignment

### DIFF
--- a/src_rebuild/Game/C/mdraw.c
+++ b/src_rebuild/Game/C/mdraw.c
@@ -384,6 +384,18 @@ void DrawMultiplayerTarget(MS_TARGET *target)
 				{
 					if(gPlayerWithTheFlag != -1)
 					{
+						if (gPlayerWithTheFlag == 1)
+						{
+							r = 0;
+							g = 128;
+							b = 0;
+						}
+						else
+						{
+							r = 128;
+							g = 0;
+							b = 0;
+						}
 						tv.vx = player[gPlayerWithTheFlag].pos[0];
 						tv.vz = player[gPlayerWithTheFlag].pos[2];
 					}

--- a/src_rebuild/Game/C/overlay.c
+++ b/src_rebuild/Game/C/overlay.c
@@ -631,7 +631,7 @@ void DrawDrivingGameOverlays(void)
 			sprintf(string, "%d", gPlayerScore.items);
 			PrintString(string, x + 3, 16);
 		
-			x = PrintString(G_LTXT(GTXT_Flags), gOverlayXPos, 132);
+			x = PrintString(G_LTXT(GTXT_Flags), gOverlayXPos, SCREEN_H / 2 + 4);
 			sprintf(string, "%d", gPlayerScore.P2items);
 			PrintString(string, x + 3, SCREEN_H / 2 + 4);
 			break;


### PR DESCRIPTION
Fixes issues mentioned in #200.